### PR TITLE
fix: make target blank great again

### DIFF
--- a/oop/index.html
+++ b/oop/index.html
@@ -8,8 +8,12 @@
 <body>
 	<div>
 		<font size="14px">
-			<a href="https://docs.google.com/presentation/d/1Ba74CkpK3NGU-AFrvqYvSnWoG5iNHriW/edit">Лекция по основам ООП</a> <br>
-			<a href="https://docs.google.com/document/d/1LU81xBOpMFs4X33Pwt066bf5DX4hQ2us7LPn1Gu2VAU/edit">Дополнительные "слайды" к лекции</a>
+			<a href="https://docs.google.com/presentation/d/1Ba74CkpK3NGU-AFrvqYvSnWoG5iNHriW/edit"
+			   target="_blank"
+			>Лекция по основам ООП</a> <br>
+			<a href="https://docs.google.com/document/d/1LU81xBOpMFs4X33Pwt066bf5DX4hQ2us7LPn1Gu2VAU/edit"
+			   target="_blank"
+			>Дополнительные "слайды" к лекции</a>
 		</font>
 	</div>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -6,18 +6,32 @@
 	</head>
 <body>
 	<div style="max-width: 600px">
-		<a href="https://drive.google.com/file/d/1AEgLAAENdNh1x26eZhwtscx6twMhtPXp/view?usp=sharing"> Вводная </a> 
+		<a href="https://drive.google.com/file/d/1AEgLAAENdNh1x26eZhwtscx6twMhtPXp/view?usp=sharing"
+		   target="_blank"
+		> Вводная </a>
 		<br>
-		<a href="https://drive.google.com/file/d/1LvmeIKXENLtoJ4SHW_SSMg6NmJ9aXjb-/view?usp=sharing"> HTML Tags </a>
+		<a href="https://drive.google.com/file/d/1LvmeIKXENLtoJ4SHW_SSMg6NmJ9aXjb-/view?usp=sharing"
+		   target="_blank"
+		> HTML Tags </a>
 		<br>
 		<br>
 		<br>
-		<a href="https://drive.google.com/file/d/1ewC5Oqdv8MLxGiWFuz1dZ_4cvUPoFuZC/view">HTML:CSS</a> <br>
-		<a href="https://drive.google.com/file/d/1_yHPyh-1HeYy4OJD-IWrLoHOtGQuZUyq/view">Блочная модель документа</a><br>
-		<a href="https://docs.google.com/presentation/d/1hn-J0_UHTAizBsKXica7vdI3nPo0z4RZ/edit#slide=id.p1">Выравнивание элементов</a><br>
-		<a href="https://docs.google.com/presentation/d/1fXMm_TbmjjwC4pNUaXuyqO8x_DSFI8Zk/edit#slide=id.p1">FLEX</a><br>
+		<a href="https://drive.google.com/file/d/1ewC5Oqdv8MLxGiWFuz1dZ_4cvUPoFuZC/view"
+		   target="_blank"
+		>HTML:CSS</a> <br>
+		<a href="https://drive.google.com/file/d/1_yHPyh-1HeYy4OJD-IWrLoHOtGQuZUyq/view"
+		   target="_blank"
+		>Блочная модель документа</a><br>
+		<a href="https://docs.google.com/presentation/d/1hn-J0_UHTAizBsKXica7vdI3nPo0z4RZ/edit#slide=id.p1"
+		   target="_blank"
+		>Выравнивание элементов</a><br>
+		<a href="https://docs.google.com/presentation/d/1fXMm_TbmjjwC4pNUaXuyqO8x_DSFI8Zk/edit#slide=id.p1"
+		   target="_blank"
+		>FLEX</a><br>
 		<hr>
-		<a href="https://docs.google.com/document/d/1ybmhKPyUyZvGaJI-3MrM9AleAW9Kzng8/edit?usp=sharing&ouid=111575169959601104712&rtpof=true&sd=true"> Лабораторные работы </a>
+		<a href="https://docs.google.com/document/d/1ybmhKPyUyZvGaJI-3MrM9AleAW9Kzng8/edit?usp=sharing&ouid=111575169959601104712&rtpof=true&sd=true"
+		   target="_blank"
+		> Лабораторные работы </a>
 		<br>
 		<hr>
 		<img src="tg-invite.png" height="40%", width="40%" />


### PR DESCRIPTION
Несколько раз я заходит пробежаться по ссылкам и хотел их открыть одновременно, чтобы по-очереди прочитать, но ссылки открывались в том же окне и данной возможности, так сказать, не представлялось.

Именно поэтому я решил возродить культуру `target: _blank`!